### PR TITLE
If configPath not found, log actual failed path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ function ensureAndGetConfigPath(): string {
     const relPath = path.join(workspacePath, relativeFilePath);
 
     if (!fs.existsSync(relPath)) {
+      core.error(`File not found at path: ${relPath}`);
       throw new Error(`File not found at path: ${relPath}`);
     }
 


### PR DESCRIPTION
It turns out, the `configPath` value gets appended to the value of the GitHub environment variable `GITHUB_WORKSPACE` when present, e.g. `/home/runner/work/myappname/myappname` such that `configPath` in that case must begin with a slash, or else the concatenation results in an invalid path.

Recommend that the error message from this library show the actual path checked for a file on failure.

Relates to #15